### PR TITLE
Implement photo move API

### DIFF
--- a/src/gallery/dto/gallery-photo-move.dto.ts
+++ b/src/gallery/dto/gallery-photo-move.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { IsArray, IsString, IsUUID } from 'class-validator'
+
+export class GalleryPhotoMoveDto {
+  @ApiProperty({ type: String, isArray: true })
+  @IsUUID(undefined, { each: true })
+  @IsArray()
+  ids: string[]
+
+  @ApiProperty({ type: String })
+  @IsString()
+  albumId: string
+}

--- a/src/gallery/photo/gallery-photo.service.ts
+++ b/src/gallery/photo/gallery-photo.service.ts
@@ -13,7 +13,7 @@ import { ProfileIdModel } from 'src/accounts/models/profile-id.model'
 import { GalleryPhotoEntity } from 'src/entities/gallery/gallery-photo.entity'
 import { BullQueueName } from 'src/enums/bull-queue-name.enum'
 import { GalleryPhotoRejectReason } from 'src/enums/gallery-photo-reject-reason.enum'
-import { Repository } from 'typeorm'
+import { Repository, In } from 'typeorm'
 
 @Injectable()
 export class GalleryPhotoService implements OnModuleDestroy {
@@ -79,6 +79,11 @@ export class GalleryPhotoService implements OnModuleDestroy {
 
   async deletePhoto(id: string) {
     await this.photoRepository.softDelete({ id })
+  }
+
+  async movePhotos(ids: string[], albumId: string) {
+    if (!ids.length) return
+    await this.photoRepository.update({ id: In(ids) }, { albumId })
   }
 
   async onModuleDestroy() {

--- a/src/gallery/photo/gallery-photo.v1.controller.ts
+++ b/src/gallery/photo/gallery-photo.v1.controller.ts
@@ -27,6 +27,7 @@ import { GalleryAlbumPhotoModel } from '../dto/gallery-album-photo.model'
 import { GalleryPhotoRejectionDto } from '../dto/gallery-photo-rejection.dto'
 import { UuidParamDto } from '../dto/uuid-param.dto'
 import { UuidsBodyDto } from '../dto/uuids-body.dto'
+import { GalleryPhotoMoveDto } from '../dto/gallery-photo-move.dto'
 import { GalleryPhotoService } from './gallery-photo.service'
 
 @Controller({ path: 'gallery/photos', version: '1' })
@@ -64,6 +65,16 @@ export class GalleryPhotoV1Controller {
   @ApiAcceptedResponse()
   async reprocessGalleryPhoto(@Param() { id }: UuidParamDto) {
     await this.galleryPhotoService.reprocess(id)
+  }
+
+  @Patch('move')
+  @AuthGroups('pr')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiBearerAuth()
+  @ApiCookieAuth()
+  @ApiNoContentResponse()
+  async moveGalleryPhotos(@Body() { ids, albumId }: GalleryPhotoMoveDto) {
+    await this.galleryPhotoService.movePhotos(ids, albumId)
   }
 
   @Patch(':id/approve')

--- a/test/gallery/gallery-photo.e2e-spec.ts
+++ b/test/gallery/gallery-photo.e2e-spec.ts
@@ -1,0 +1,40 @@
+import { HttpStatus, INestApplication } from '@nestjs/common'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import expect from 'expect'
+import { GalleryPhotoEntity } from 'src/entities/gallery/gallery-photo.entity'
+import request from 'supertest'
+import { TestData } from 'test/test-data'
+import { Repository, In } from 'typeorm'
+
+describe('Gallery photo', () => {
+  let app: INestApplication
+  let photoRepository: Repository<GalleryPhotoEntity>
+  let prCookie: string[]
+
+  beforeAll(async () => {
+    app = await TestData.aValidApp().build()
+    prCookie = TestData.aValidSupertestCookies()
+      .withAccessToken(await TestData.aValidAccessToken().withGroups('pr').build())
+      .build()
+  })
+
+  beforeEach(async () => {
+    photoRepository = await app.get(getRepositoryToken(GalleryPhotoEntity))
+  })
+
+  test('PATCH /api/v1/gallery/photos/move', async () => {
+    const body = { albumId: 'newAlbum', ids: ['id1', 'id2'] }
+    photoRepository.update = jest.fn().mockResolvedValue({ affected: 2 })
+    const result = await request(app.getHttpServer())
+      .patch('/api/v1/gallery/photos/move')
+      .set('Cookie', prCookie)
+      .send(body)
+
+    expect(result.status).toBe(HttpStatus.NO_CONTENT)
+    expect(photoRepository.update).toHaveBeenCalledWith({ id: In(body.ids) }, { albumId: body.albumId })
+  })
+
+  afterAll(() => {
+    app.close()
+  })
+})


### PR DESCRIPTION
## Summary
- add `GalleryPhotoMoveDto`
- allow `GalleryPhotoService` to move photos between albums
- expose new `PATCH /api/v1/gallery/photos/move` endpoint
- test moving photos
- handle empty list gracefully

## Testing
- `pnpm install --frozen-lockfile`
- `npm test` *(fails: Object.groupBy is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_687e1d1fd17c83228eec6fb89050845e